### PR TITLE
On Neko targets, SignalBase.remove() fails to find and remove the listener.

### DIFF
--- a/src/ash/signals/SignalBase.hx
+++ b/src/ash/signals/SignalBase.hx
@@ -152,7 +152,7 @@ class SignalBase<TListener>
         node = head;
         while (node != null)
         {
-            if (node.listener == listener)
+            if (Reflect.compareMethods(node.listener, listener))
             {
                 foundNode = true;
                 break;
@@ -165,7 +165,7 @@ class SignalBase<TListener>
             node = toAddHead;
             while (node != null)
             {
-                if (node.listener == listener)
+            	if (Reflect.compareMethods(node.listener, listener))
                 {
                     foundNode = true;
                     break;


### PR DESCRIPTION
My game which has a significant number of entities slows to a crawl on Neko. It happens whenever an entity is removed from a node list while the Ash engine is mid-update. ComponentMatchingFamily removes the entity and node, puts the node on-deck for the node pool, then hooks into Engine.updateComplete. When the engine finishes updating, the callback releases the on-deck node into the pool. It does this part fine, but then the callback tries to remove itself from the updateComplete signal. This fails. The signal remains, and over a time the signals accumulate, dragging the app to a standstill.

The failure appears to be in SignalBase.remove. In two locations, nodes in the linked list are compared to the listener, but the comparison returns false on Neko. 

```
       node = head;
        while (node != null)
        {
            if (node.listener == listener)
            {
                foundNode = true;
                break;
            }
            node = node.next;
        }
```

CPP makes the compare successfully. I changed the comparison to this:

```
            if (Reflect.compareMethods(node.listener, listener))
```

And that seems to fix the problem. There are other comparisons in that method which may suffer from the same comparison problem, I don't know, but changing these two fixed an egregious problem for me.

I'm on Neko 1.x and Haxe 2.1, but I've had this problem for a while and I'm pretty sure it was present when I was messing around with Neko 2.
