### PR TITLE
Updated KeyPoll.hx and added getKeysDown() method

### DIFF
--- a/examples/asteroids/net/richardlord/input/KeyPoll.hx
+++ b/examples/asteroids/net/richardlord/input/KeyPoll.hx
@@ -49,6 +49,12 @@ class KeyPoll
     private var states:Bytes;
     private var dispObj:DisplayObject;
 
+    private var mod37BitPosition:Array<Int> = [
+        32, 0, 1, 26, 2, 23, 27, 0, 3, 16, 24, 30, 28, 11, 0, 13,
+        4, 7, 17, 0, 25, 22, 31, 15, 29, 10, 12, 6, 0, 21, 14, 9,
+        5, 20, 8, 19, 18
+    ];
+    
     /**
      * Constructor
      *
@@ -56,7 +62,7 @@ class KeyPoll
      */
     public function new(displayObj:DisplayObject)
     {
-        states = Bytes.alloc(8);
+        states = Bytes.alloc(32);
         dispObj = displayObj;
 		
         dispObj.addEventListener(KeyboardEvent.KEY_DOWN, keyDownListener);
@@ -117,5 +123,27 @@ class KeyPoll
     public function isUp(keyCode:Int):Bool
     {
         return ( states.get(keyCode >>> 3) & (1 << (keyCode & 7)) ) == 0;
+    }
+    
+    /**
+     * Get a list of keys that are down.
+     *
+     * @returns A list of keyCodes for each key down.
+     */
+    public function getKeysDown():Array<Int> {
+        var keyCodes:Array<Int> = new Array<Int>();
+        var v:Int;
+
+        for (i in 0...states.length) {
+            v = states.get(i);
+
+            while(v != 0) {
+                keyCodes.push( (mod37BitPosition[(-v & v) % 37]) + (i << 3) );
+                v &= v - 1;     // Clear least significant bit set
+            }
+
+        }
+
+        return keyCodes;
     }
 }


### PR DESCRIPTION
Previous implementation only handled keys with codes in the range 0-64. Extended the range to handle key codes from 0 to 255. Also added a method to retrieve a list of keys currently down.