### PR TITLE
Add ability to set priority when adding Systems to EngineState

### DIFF
--- a/src/ash/core/Engine.hx
+++ b/src/ash/core/Engine.hx
@@ -25,6 +25,8 @@ class Engine
 
     public var entityAdded(default, null):Signal1<Entity>;
     public var entityRemoved(default, null):Signal1<Entity>;
+    public var systemAdded(default, null):Signal1<System>;
+    public var systemRemoved(default, null):Signal1<System>;
 
     /**
      * Dispatched when the update loop ends. If you want to add and remove systems from the
@@ -50,6 +52,8 @@ class Engine
         families = new ClassMap();
         entityAdded = new Signal1<Entity>();
         entityRemoved = new Signal1<Entity>();
+        systemAdded = new Signal1<System>();
+        systemRemoved = new Signal1<System>();
         updateComplete = new Signal0();
         updating = false;
     }
@@ -224,6 +228,7 @@ class Engine
         system.priority = priority;
         system.addToEngine(this);
         systemList.add(system);
+        systemAdded.dispatch(system);
     }
 
     /**
@@ -257,6 +262,7 @@ class Engine
     {
         systemList.remove(system);
         system.removeFromEngine(this);
+        systemRemoved.dispatch(system);
     }
 
     /**

--- a/src/ash/fsm/DynamicSystemProvider.hx
+++ b/src/ash/fsm/DynamicSystemProvider.hx
@@ -29,9 +29,10 @@ class DynamicSystemProvider<T:System> implements ISystemProvider<T>
      *
      * @param method The method that returns the System instance;
      */
-    public function new(method:DynamicSystemProviderClosure<T>)
+    public function new(method:DynamicSystemProviderClosure<T>, priority:Int = 0)
     {
         this.method = method;
+        this.priority = priority;
     }
 
     /**

--- a/src/ash/fsm/EngineState.hx
+++ b/src/ash/fsm/EngineState.hx
@@ -24,9 +24,9 @@ class EngineState
      * @return This StateSystemMapping, so more modifications can be applied
      */
 
-    public inline function addInstance<T:System>(system:T):StateSystemMapping<T>
+    public inline function addInstance<T:System>(system:T, priority:Int = 0):StateSystemMapping<T>
     {
-        return addProvider(new SystemInstanceProvider( system ));
+        return addProvider(new SystemInstanceProvider( system, priority ));
     }
 
     /**
@@ -40,10 +40,9 @@ class EngineState
      * @return This StateSystemMapping, so more modifications can be applied
      */
 
-    public function addSingleton<T:System>(type:Class<T>):StateSystemMapping<T>
+    public function addSingleton<T:System>(type:Class<T>, priority:Int = 0):StateSystemMapping<T>
     {
-        return addProvider(new SystemSingletonProvider( type ));
-
+        return addProvider(new SystemSingletonProvider( type, priority ));
     }
 
     /**
@@ -55,9 +54,9 @@ class EngineState
      * @return This StateSystemMapping, so more modifications can be applied.
      */
 
-    public function addMethod<T:System>(method:DynamicSystemProviderClosure<T>):StateSystemMapping<T>
+    public function addMethod<T:System>(method:DynamicSystemProviderClosure<T>, priority:Int = 0):StateSystemMapping<T>
     {
-        return addProvider(new DynamicSystemProvider( method ));
+        return addProvider(new DynamicSystemProvider( method, priority ));
     }
 
     /**

--- a/src/ash/fsm/SystemInstanceProvider.hx
+++ b/src/ash/fsm/SystemInstanceProvider.hx
@@ -28,9 +28,10 @@ class SystemInstanceProvider<T:System> implements ISystemProvider<T>
      *
      * @param instance The instance to return whenever a System is requested.
      */
-    public function new(instance:T)
+    public function new(instance:T, priority:Int = 0)
     {
         this.instance = instance;
+        this.priority = priority;
     }
 
     /**

--- a/src/ash/fsm/SystemSingletonProvider.hx
+++ b/src/ash/fsm/SystemSingletonProvider.hx
@@ -29,9 +29,10 @@ class SystemSingletonProvider<T:System> implements ISystemProvider<T>
      *
      * @param type The type of the single System instance
      */
-    public function new(type:Class<T>)
+    public function new(type:Class<T>, priority:Int = 0)
     {
         this.componentType = type;
+        this.priority = priority;
     }
 
     /**


### PR DESCRIPTION
Commit https://github.com/IkonicGames/Ash-Haxe/commit/72fbcdd2d9fb93863b9eb1a3181d2f8fbde86e6d is a solution to issue #25 

I provided default values for the priority variables in the function parameters to maintain backwards compatibility.

Commit https://github.com/IkonicGames/Ash-Haxe/commit/8f73662fd9d079b6965bb6a923a8b5c21fda4780 is a solution to issue #24 

After looking at the code, changing to the foreach was not going to work to fix the issue for every case.  A fringe example would be 2 EngineStates share the same System that depends on another System that is switched out with each state.  Simply changing the For loop would not address this use case.  Adding signals to the Engine addresses every case I could think of and is a useful feature as well.  Imho at least.