### PR TITLE
Fix crash bug in Engine.removeAllSystems().

### DIFF
--- a/src/ash/core/Engine.hx
+++ b/src/ash/core/Engine.hx
@@ -267,12 +267,10 @@ class Engine
     {
         while (systemList.head != null)
         {
-          var system : System = systemList.head;
-            systemList.head = systemList.head.next;
+            var system : System = systemList.head;
+            removeSystem(system);
             system.previous = null;
             system.next = null;
-            system.removeFromEngine( this );
-            removeSystem(systemList.head);
         }
         systemList.tail = null;
     }


### PR DESCRIPTION
The method used to manually advance systemList.head and call
system.removeFromEngine(), but removeSystem() already takes care of
that. This eventually resulted in a null reference. The offending lines
were removed, and the next and previous pointers were set to null
*after* calling removeSystem instead.