### PR TITLE
Adds .contains() methods to Engine, EntityList and ComponentPool.

### DIFF
--- a/src/ash/core/Engine.hx
+++ b/src/ash/core/Engine.hx
@@ -75,6 +75,10 @@ class Engine
         }
         entityAdded.dispatch(entity);
     }
+    
+    public function contains(entity: Entity): Bool {
+        return entityList.contains(entity);
+    }
 
     /**
      * Remove an entity from the engine.

--- a/src/ash/core/EntityList.hx
+++ b/src/ash/core/EntityList.hx
@@ -43,6 +43,17 @@ class EntityList
             entity.next.previous = entity.previous;
         // N.B. Don't set entity.next and entity.previous to null because that will break the list iteration if entity is the current entity in the iteration.
     }
+    
+    public function contains(entity: Entity): Bool
+    {
+        var node = head;
+        while (node != null) {
+            if (node == entity)
+                return true;
+            node = node.next;
+        }
+        return false;
+    }
 
     public function removeAll():Void
     {

--- a/src/ash/tools/ComponentPool.hx
+++ b/src/ash/tools/ComponentPool.hx
@@ -71,6 +71,17 @@ class ComponentPool
             pool.push(component);
         }
     }
+    
+    public static function contains<TComponent>(component: TComponent): Bool
+    {
+        if (component != null)
+        {
+            var type:Class<TComponent> = Type.getClass(component);
+            var pool:Array<TComponent> = getPool(type);
+            return pool.indexOf(component) >= 0;
+        }
+        return false;
+    }
 
     /**
      * Dispose of all pooled resources, freeing them for garbage collection.


### PR DESCRIPTION
Useful while debugging to detect if an entity that should have been removed is still in the engine, or if an active component is somehow still in the ComponentPool (maybe because it got added twice).