### PR TITLE
Fix name collisions in NodeMacro

### DIFF
--- a/src/ash/core/NodeMacro.hx
+++ b/src/ash/core/NodeMacro.hx
@@ -30,7 +30,11 @@ class NodeMacro
                             // TODO: add support for type parameters
                             if (path.params.length > 0)
                                 throw new Error("Type parameters for node field types are not yet supported yet", field.pos);
-                            populateExprs.push(macro _components.set($i{path.name}, $v{field.name}));
+
+                            var namePath = path.pack.copy();
+                            namePath.push(path.name);
+                            populateExprs.push(macro _components.set($p{namePath}, $v{field.name}));
+
                         default:
                             throw new Error("Invalid node class with field type other than class: " + field.name, field.pos);
                     }


### PR DESCRIPTION
This fixes the following case:

```haxe
class RocketNode extends Node<RocketNode> {
    public var logicRocket:game.logic.Rocket;
    public var displayRocket:game.display.Rocket;
}
```

The class name was used without its full path so ending in name collisions.
